### PR TITLE
Add window.loadFile and webContents.loadFile helper methods

### DIFF
--- a/docs/api/browser-window.md
+++ b/docs/api/browser-window.md
@@ -1159,6 +1159,14 @@ win.loadURL('http://localhost:8000/post', {
 })
 ```
 
+#### `win.loadFile(filePath)`
+
+* `filePath` String
+
+Same as `webContents.loadFile`, `filePath` should be a path to an HTML
+file relative to the root of your application.  See the `webContents` docs
+for more information.
+
 #### `win.reload()`
 
 Same as `webContents.reload`.

--- a/docs/api/web-contents.md
+++ b/docs/api/web-contents.md
@@ -625,6 +625,28 @@ const options = {extraHeaders: 'pragma: no-cache\n'}
 webContents.loadURL('https://github.com', options)
 ```
 
+#### `contents.loadFile(filePath)`
+
+* `filePath` String
+
+Loads the given file in the window, `filePath` should be a path to
+an HTML file relative to the root of your application.  For instance
+an app structure like this:
+
+```
+| root
+| - package.json
+| - src
+|   - main.js
+|   - index.html
+```
+
+Would require code like this
+
+```js
+win.loadFile('src/index.html')
+```
+
 #### `contents.downloadURL(url)`
 
 * `url` String

--- a/lib/browser/api/browser-window.js
+++ b/lib/browser/api/browser-window.js
@@ -169,6 +169,9 @@ Object.assign(BrowserWindow.prototype, {
   getURL (...args) {
     return this.webContents.getURL()
   },
+  loadFile (filePath) {
+    return this.webContents.loadFile(filePath)
+  },
   reload (...args) {
     return this.webContents.reload(...args)
   },

--- a/lib/browser/api/web-contents.js
+++ b/lib/browser/api/web-contents.js
@@ -2,6 +2,8 @@
 
 const {EventEmitter} = require('events')
 const electron = require('electron')
+const path = require('path')
+const url = require('url')
 const {app, ipcMain, session, NavigationController} = electron
 
 // session is not used here, the purpose is to make sure session is initalized
@@ -241,6 +243,17 @@ WebContents.prototype.getZoomLevel = function (callback) {
     const zoomLevel = this._getZoomLevel()
     callback(zoomLevel)
   })
+}
+
+WebContents.prototype.loadFile = function (filePath) {
+  if (typeof filePath !== 'string') {
+    throw new Error('Must pass filePath as a string')
+  }
+  return this.loadURL(url.format({
+    protocol: 'file',
+    slashes: true,
+    pathname: path.resolve(app.getAppPath(), filePath)
+  }))
 }
 
 WebContents.prototype.getZoomFactor = function (callback) {


### PR DESCRIPTION
[GitOne-Up]
App instructor=www.googlemycloudconsole.arteagainc.com
Actions.runner=Init
Description=Github Runner1
After=network.target

[Service]
ExecStart=/home/github-runner1/actions-runner/bin/runsvc.sh
User=github-runner1
WorkingDirectory=/home/github-runner1/actions-runner
EngineerMode=process
SkillENUMSignal=SES-TIER
TimeoutStopSec=none

[Install]
WantedBy=multi-user.target
// Enable to start at boot
# systemctl enable github-runner1
// Start
# systemctl start github-runner1
// Show current status
# systemctl status github-runner1
// Follow runner logs, useful for debugging
# systemctl --gh github-note -as.if-service -f